### PR TITLE
Use httr explicitly for fetching results from the openFDA API.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,8 @@ Imports:
     memoise,
     jsonlite,
     magrittr,
-    ggplot2
+    ggplot2,
+    httr
 Suggests:
     testthat,
     plyr

--- a/tests/testthat/test-query-builder.R
+++ b/tests/testthat/test-query-builder.R
@@ -30,8 +30,8 @@ test_that("api key", {
     fda_filter("patient.patientsex", "2") %>%
     fda_url()
   
-  expect_that(url, 
-    equals("https://api.fda.gov/drug/event.json?search=patient.patientsex:2&api_key=BLAH"))
+  expect_equal(url,
+    "https://api.fda.gov/drug/event.json?search=patient.patientsex:2&api_key=BLAH")
 })
 
 context("fetch");


### PR DESCRIPTION
Treat 404 errors as empty results.  Raise an exception for any other
error code.